### PR TITLE
Fix problems on systems where text and binary modes of operation behave differently (Windows)

### DIFF
--- a/dump_projector.c
+++ b/dump_projector.c
@@ -16,7 +16,7 @@ Example: `dump_projector application.exe application.swf`\r\n");
       return 1;
    }
 
-   hfInput = fopen(argv[1], "r");
+   hfInput = fopen(argv[1], "rb");
    if (hfInput == NULL) {
       printf("Cannot open input file for reading!\r\n");
    } else {
@@ -28,7 +28,7 @@ Example: `dump_projector application.exe application.swf`\r\n");
          if (hMemHeap != NULL) {
 	    fseek(hfInput, szFile-*(uint32_t*)&dataEnd[4], SEEK_SET);
             lpNumberOfBytesRW = fread(hMemHeap, 1, *(uint32_t*)&dataEnd[4], hfInput);
-            hfOutput = fopen(argv[2], "w");
+            hfOutput = fopen(argv[2], "wb");
             if (hfOutput == NULL) {
                printf("Cannot create output file for writing!\r\n");
             } else {


### PR DESCRIPTION
This patch fixes the program so that it correctly behaves on both POSIX-compliant and Windows based systems. Under Windows, file operations have different behavior when working on text files than they do on binary files. adding a 'b' to `fopen`'s 'mode' strings for reading and writing makes this program behave properly on Windows, while also continuing to work on POSIX systems.

Tested from my Debian Box, where I cross-compiled using MinGW-w64 and ran the resulting program in Wine.